### PR TITLE
Update to scalaz-7.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "scala-abt"
 
 organization := "com.slamdata"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 // Resolvers
 resolvers ++= Seq(
@@ -33,13 +33,12 @@ scalacOptions ++= Seq(
 
 // Compile Dependencies
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-core" % "7.1.4",
-
-  "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+  "org.scalaz"     %% "scalaz-core" % "7.2.2",
+  "org.scalacheck" %% "scalacheck"  % "1.12.5" % "test"
 )
 
 // Wartremover
 wartremoverErrors ++= Warts.allBut(Wart.Throw)
 
 // Kind Projector
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")

--- a/src/main/scala/abt/Abt.scala
+++ b/src/main/scala/abt/Abt.scala
@@ -8,19 +8,24 @@ import scalaz._
   * @tparam T Abt concrete instance
   */
 trait Abt[S, V, O, T] {
-  def check[M[_, _]](view: View[V, O, T], valence: Valence[S])
-                    (implicit ME: MonadError[M, AbtError[S, V]],
-                              MV: MonadVar[M[AbtError[S, V], ?], V],
-                              O:  Operator[S, O],
-                              SE: Equal[S],
-                              SV: Equal[V])
-                    : M[AbtError[S, V], T]
+  def check[F[_]](
+    view: View[V, O, T],
+    valence: Valence[S]
+  )(implicit
+    ME: MonadError[F, AbtError[S, V]],
+    MV: MonadVar[F, V],
+    O:  Operator[S, O],
+    SE: Equal[S],
+    SV: Equal[V]
+  ): F[T]
 
-  def infer[M[_, _]](t: T)
-                    (implicit ME: MonadError[M, AbtError[S, V]],
-                              MV: MonadVar[M[AbtError[S, V], ?], V],
-                              O:  Operator[S, O])
-                    : M[AbtError[S, V], (Valence[S], View[V, O, T])]
+  def infer[F[_]](
+    t: T
+  )(implicit
+    ME: MonadError[F, AbtError[S, V]],
+    MV: MonadVar[F, V],
+    O:  Operator[S, O]
+  ): F[(Valence[S], View[V, O, T])]
 }
 
 object Abt {


### PR DESCRIPTION
Updates scalaz and kind-projector dependencies to their latest stable versions.

Was able to clean up the `Abt` signatures a bit thanks to the reformulation of the `mtl`-ish types in scalaz-7.2.x
